### PR TITLE
Add environmentConfig to api radix component

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -27,6 +27,8 @@ spec:
           cpu: 500m
           memory: 8000M
     - name: api
+      environmentConfig:
+        - environment: dev
       dockerfileName: Dockerfile_api
       ports:
         - name: http
@@ -38,5 +40,3 @@ spec:
         requests:
           cpu: 500m
           memory: 8000M
-
-          


### PR DESCRIPTION
This is needed for the legacy-dash environment as it doesn't have api component