### PR TITLE
remove async from api endpoint

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -63,7 +63,7 @@ class SimulationRequest(BaseModel):
 
 
 @app.post("/run_simulation")
-async def run_simulation(form: SimulationRequest):
+def run_simulation(form: SimulationRequest):
     results = traverse(
         form.temperature,
         form.pressure,


### PR DESCRIPTION
Seems that if both acidwatch api and arcs api are async, acidwatch will actually not handle concurrent requests. If acidwatch api are async and arcs sync it seems to wokr fine. Need to investigate more, this is for verifying same behaviour in radix as in local